### PR TITLE
V1.7.0

### DIFF
--- a/AyanTechNetworkingLibrary.podspec
+++ b/AyanTechNetworkingLibrary.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |spec|
   spec.swift_version = "5.0"
   spec.platform = :ios, "11.0"
   spec.requires_arc = true
-  spec.source = { git: "https://github.com/AyanTech/AyanTechNetworkingLibrary-iOS.git", tag: "v#{spec.version}", submodules: true }
+  spec.source = { http: "https://github.com/AyanTech/AyanTechNetworkingLibrary-iOS/archive/refs/heads/master.zip", git: "https://github.com/AyanTech/AyanTechNetworkingLibrary-iOS.git", tag: "v#{spec.version}", submodules: true }
   spec.source_files = "AyanTechNetworkingLibrary/**/*.{h,swift}"
 end

--- a/AyanTechNetworkingLibrary.podspec
+++ b/AyanTechNetworkingLibrary.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |spec|
   spec.swift_version = "5.0"
   spec.platform = :ios, "11.0"
   spec.requires_arc = true
-  spec.source = { :git => "https://github.com/AyanTech/AyanTechNetworkingLibrary-iOS.git", :tag => 'v#{spec.version}', submodules: true }
+  spec.source = { :git => "https://github.com/AyanTech/AyanTechNetworkingLibrary-iOS.git", tag: "v#{spec.version}", submodules: true }
   spec.source_files = "AyanTechNetworkingLibrary/**/*.{h,swift}"
 end

--- a/AyanTechNetworkingLibrary.podspec
+++ b/AyanTechNetworkingLibrary.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |spec|
   spec.swift_version = "5.0"
   spec.platform = :ios, "11.0"
   spec.requires_arc = true
-  spec.source = { :git => "https://github.com/AyanTech/AyanTechNetworkingLibrary-iOS.git", tag: "v#{spec.version}", submodules: true }
+  spec.source = { :git => "https://github.com/AyanTech/AyanTechNetworkingLibrary-iOS.git", branch: "v#{spec.version}", submodules: true }
   spec.source_files = "AyanTechNetworkingLibrary/**/*.{h,swift}"
 end

--- a/AyanTechNetworkingLibrary.podspec
+++ b/AyanTechNetworkingLibrary.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |spec|
   spec.swift_version = "5.0"
   spec.platform = :ios, "11.0"
   spec.requires_arc = true
-  spec.source = { http: "https://github.com/AyanTech/AyanTechNetworkingLibrary-iOS/archive/refs/heads/master.zip", git: "https://github.com/AyanTech/AyanTechNetworkingLibrary-iOS.git", tag: "v#{spec.version}", submodules: true }
+  spec.source = { :git => "https://github.com/AyanTech/AyanTechNetworkingLibrary-iOS.git", :tag => 'v#{spec.version}', submodules: true }
   spec.source_files = "AyanTechNetworkingLibrary/**/*.{h,swift}"
 end


### PR DESCRIPTION
## Task

Merge `v1.7.0` commits into `master`. 

## Changes

- Merge `v1.7.0` podspec fixes into `master`.

## Risks / Notes

- Suggestion: after merge, tag `v1.7.0` on `master` to match the podspec version, enabling apps using SPM to pin to `1.7.0` instead of tracking `master`.